### PR TITLE
solr volume updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - solr_data:/opt/solr/server/solr/ckan/data/index
+      - solr_data:/opt/solr/server/solr/ckan/data
 
   redis:
     image: redis:alpine

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6.6.2
+FROM solr:6.6.6
 
 # Enviroment
 ENV SOLR_CORE ckan
@@ -19,7 +19,6 @@ https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.2/
 
 # Create Core.properties
 RUN echo name=$SOLR_CORE > /opt/solr/server/solr/$SOLR_CORE/core.properties
-RUN echo dataDir=$/opt/solr/server/solr/$SOLR_CORE/data > /opt/solr/server/solr/$SOLR_CORE/core.properties
 
 # Giving ownership to Solr
 


### PR DESCRIPTION
Remove the data volume path specification, as that is the default and was misnamed.
Per Docker documentation, the volume folder will inherit owner/permissions from parent file. Move volume folder up 1 level to set permissions properly.
Use latest Solr 6.6