### PR TITLE
DB Docker Build Bug Fix

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -2,7 +2,7 @@
 FROM mdillon/postgis:11
 
 # Allow connections; we don't map out any ports so only linked docker containers can connect
-RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
+# RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
 
 # Customize default user/pass/db
 ENV POSTGRES_DB ckan


### PR DESCRIPTION

<img width="1440" alt="postgresql_dockerfile_bug_fix_20210527_09_42_cst" src="https://user-images.githubusercontent.com/74677943/119846609-e71edf80-becf-11eb-9b32-a489ac60074a.png">
Bug in which the postgres dockerfile would crash unless

/var/lib/postgresql/data  is empty
commenting out line 5 in postgresql/Dockerfile

fixes this issue and allows the site to be run locally

solves: 
```
ckan-web_1     | could not translate host name "db" to address: Name does not resolve
ckan-worker_1  | Option unchanged ckanext.geodatagov.fgdc2iso_service = "http://app:8080/fgdc2iso/" (section "app:main")
ckan-worker_1  | Option unchanged ckan.plugins = "envvars image_view text_view recline_view datagov_harvest ckan_harvester geodatagov datajson datajson_harvest geodatagov_miscs z3950_harvester arcgis_harvester geodatagov_geoportal_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query spatial_harvest_metadata_api datagovtheme datagovcatalog googleanalyticsbasic dcat dcat_json_interface structured_data" (section "app:main")
ckan-web_1     | 
ckan-web_1     | [prerun] Unable to connect to the database, waiting...
ckan-web_1     | could not translate host name "db" to address: Name does not resolve
```
```
db_1           | initdb: directory "/var/lib/postgresql/data" exists but is not empty
db_1           | If you want to create a new database system, either remove or empty
db_1           | the directory "/var/lib/postgresql/data" or run initdb
db_1           | with an argument other than "/var/lib/postgresql/data".
```
